### PR TITLE
Fixup return values from private upload (uploadImageAnon) method

### DIFF
--- a/lib/Web/Imgur.pm
+++ b/lib/Web/Imgur.pm
@@ -46,10 +46,11 @@ sub uploadImageAnon {
 	if ($req->is_success) {
 		my $message = $req->decoded_content;
 		my $json = from_json($message);
-		print $json->{"data"}{"link"};
+		return $json->{"data"}{"link"};
 	} else {
-		print "HTTP POST error code: ", $req->code, "\n";
-		print "HTTP POST error message: ", $req->message, "\n";
+		print STDERR "HTTP POST error code: ", $req->code, "\n";
+		print STDERR "HTTP POST error message: ", $req->message, "\n";
+		return undef;
 	}
 }
 


### PR DESCRIPTION
Don't print to the terminal directly from the private upload method; instead, return the created URL and let the caller decide what to do with it.

This is what both the docs and the code already say should be happening.
